### PR TITLE
Adds some metrics related to job locks and executions

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -18,7 +18,7 @@ jobs:
     - name: Setup .NET
       uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: 6.0.x
+        dotnet-version: 8.0.x
     - name: Restore dependencies
       run: dotnet restore
     - name: Build

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -17,7 +17,7 @@ jobs:
     - name: Setup .NET
       uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: 7.0.x
+        dotnet-version: 8.0.x
     - name: Restore dependencies
       run: dotnet restore
     - name: Build

--- a/src/SimpleRecurringJobs.Samples.AspNetCore/SimpleRecurringJobs.Samples.AspNetCore.csproj
+++ b/src/SimpleRecurringJobs.Samples.AspNetCore/SimpleRecurringJobs.Samples.AspNetCore.csproj
@@ -7,6 +7,8 @@
 
     <ItemGroup>
         <PackageReference Include="Swashbuckle.AspNetCore" Version="5.6.3" />
+        <PackageReference Include="OpenTelemetry.Exporter.Prometheus.AspNetCore" Version="1.5.0-alpha.1" />
+        <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.9.0" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/SimpleRecurringJobs.Samples.AspNetCore/Startup.cs
+++ b/src/SimpleRecurringJobs.Samples.AspNetCore/Startup.cs
@@ -11,6 +11,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using Microsoft.OpenApi.Models;
+using OpenTelemetry.Metrics;
 using SimpleRecurringJobs.InMemory;
 
 namespace SimpleRecurringJobs.Samples.AspNetCore;
@@ -39,6 +40,8 @@ public class Startup
         );
 
         services.AddSimpleRecurringJobs(b => b.UseInMemoryJobStore().WithJob<SimpleJob>());
+
+        services.AddOpenTelemetry().WithMetrics(b => b.AddMeter("SimpleRecurringJobs").AddPrometheusExporter());
     }
 
     // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.
@@ -54,6 +57,8 @@ public class Startup
         }
 
         app.UseHttpsRedirection();
+        
+        app.UseOpenTelemetryPrometheusScrapingEndpoint();
 
         app.UseRouting();
 

--- a/src/SimpleRecurringJobs.Tests.Mongo/SimpleRecurringJobs.Tests.Mongo.csproj
+++ b/src/SimpleRecurringJobs.Tests.Mongo/SimpleRecurringJobs.Tests.Mongo.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net7.0</TargetFramework>
+        <TargetFramework>net8.0</TargetFramework>
         <Nullable>enable</Nullable>
         <IsPackable>false</IsPackable>
     </PropertyGroup>

--- a/src/SimpleRecurringJobs.Tests.Postgres/SimpleRecurringJobs.Tests.Postgres.csproj
+++ b/src/SimpleRecurringJobs.Tests.Postgres/SimpleRecurringJobs.Tests.Postgres.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net7.0</TargetFramework>
+        <TargetFramework>net8.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
     </PropertyGroup>

--- a/src/SimpleRecurringJobs.Tests.Redis/SimpleRecurringJobs.Tests.Redis.csproj
+++ b/src/SimpleRecurringJobs.Tests.Redis/SimpleRecurringJobs.Tests.Redis.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net7.0</TargetFramework>
+        <TargetFramework>net8.0</TargetFramework>
         <Nullable>enable</Nullable>
 
         <IsPackable>false</IsPackable>

--- a/src/SimpleRecurringJobs.Tests/SimpleRecurringJobs.Tests.csproj
+++ b/src/SimpleRecurringJobs.Tests/SimpleRecurringJobs.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/src/SimpleRecurringJobs/JobMetrics.cs
+++ b/src/SimpleRecurringJobs/JobMetrics.cs
@@ -1,0 +1,16 @@
+﻿using System.Diagnostics.Metrics;
+
+namespace SimpleRecurringJobs;
+
+internal class JobMetrics(Meter meter)
+{
+    public Counter<long> JobStarted { get; } = meter.CreateCounter<long>("srj_job_started", description: "Increments once each time a job is started.");
+    public Counter<long> JobCompleted { get; } = meter.CreateCounter<long>("srj_job_completed", description: "Increments once each time a job completes, either successfully or with an error.");
+    public Counter<long> JobDurationInMs { get; } = meter.CreateCounter<long>("srj_job_duration_in_ms", description: "Counts the total time spent in a job.");
+    
+    public Counter<long> JobLockAttemptStarted { get; } = meter.CreateCounter<long>("srj_job_lock_attempt_started", description: "Increments once each time a job lock is attempted to be acquired.");
+    
+    public Counter<long> JobLockAttemptCompleted { get; } = meter.CreateCounter<long>("srj_job_lock_attempt_completed", description: "Increments once each time a job lock is either acquired or not.");
+    
+    public Counter<long> JobLockAttemptDurationInMs { get; } = meter.CreateCounter<long>("srj_job_lock_attempt_duration_in_ms", description: "Counts the total time spent acquiring job locks.");
+}

--- a/src/SimpleRecurringJobs/ServiceCollectionExtensions.cs
+++ b/src/SimpleRecurringJobs/ServiceCollectionExtensions.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Diagnostics.Metrics;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using SimpleRecurringJobs.Interval;
@@ -12,6 +13,7 @@ public static class ServiceCollectionExtensions
         services.AddSingleton<IJobLogger, MicrosoftLogger>();
         services.AddSingleton<IJobScheduler, IntervalScheduler>();
         services.AddSingleton<IJobExecutor, JobsExecutor>();
+        services.AddSingleton(new JobMetrics(new Meter("SimpleRecurringJobs")));
 
         services.AddSingleton(IJobClock.SystemClock);
         services.AddSingleton(IAsyncDelayer.SystemDelayer);


### PR DESCRIPTION
Specifically, 3 metrics each for "Job Execution" and "Job Locks" indicating their start, completion (with ok/error status) and the total duration spent executing jobs or acquiring locks