### PR TITLE
Update Mongo package to support MongoDB.Driver V3

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,8 @@ var mongoConnStr = ...; // Get MongoDB connection string from somewhere.
 services.AddSimpleRecurringJobs(b => b.UseMongoJobStore(mongoConnStr, o => o.Database = "MyAppDb").WithJob<SimpleJob>());
 ```
 
+Note: If using v2.x of the `MongoDB.Driver` nuget package, you must use v1.1.36 of `SimpleRecurringJobs.Mongo`. Later versions will use `MongoDB.Driver` v3 which is incompatible with earlier versions.
+
 ## Postgres
 [![NuGet version (SimpleRecurringJobs.Postgres)](https://img.shields.io/nuget/v/SimpleRecurringJobs.Postgres.svg?style=flat-square)](https://www.nuget.org/packages/SimpleRecurringJobs.Postgres/)
 

--- a/src/SimpleRecurringJobs.Mongo/SimpleRecurringJobs.Mongo.csproj
+++ b/src/SimpleRecurringJobs.Mongo/SimpleRecurringJobs.Mongo.csproj
@@ -10,7 +10,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="MongoDB.Driver" Version="2.19.0" />
+    <PackageReference Include="MongoDB.Driver" Version="3.0.0" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Note: V3 of MongoDB.Driver is not compatible with V2.
If consumers of SRJ want to update SRJ but not use Mongo V3 they will need to pin SimpleRecurringJobs.Mongo to 1.1.36 which is the latest build using MongoDB.Driver V2.